### PR TITLE
Update runtime to GNOME 46

### DIFF
--- a/shared-modules/libreoffice-24.2.4.2.json
+++ b/shared-modules/libreoffice-24.2.4.2.json
@@ -35,7 +35,7 @@
                 {
                     "type": "git",
                     "url": "https://git.libreoffice.org/core",
-                    "tag": "libreoffice-7.5.4.2",
+                    "tag": "libreoffice-24.2.4.2",
                     "disable-fsckobjects": true
                 },
                 {

--- a/work.openpaper.Paperwork.json
+++ b/work.openpaper.Paperwork.json
@@ -24,7 +24,7 @@
         "--env=LIBO_FLATPAK=1"
     ],
     "modules": [
-        "shared-modules/libreoffice-7.5.4.2.json",
+        "shared-modules/libreoffice-24.2.4.2.json",
         "shared-modules/setuptools-65.6.3.json",
         "shared-modules/scikit-learn-1.2.0.json",
         "shared-modules/sane-backends-1.1.1.json",

--- a/work.openpaper.Paperwork.json
+++ b/work.openpaper.Paperwork.json
@@ -1,7 +1,7 @@
 {
     "app-id": "work.openpaper.Paperwork",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "paperwork-gtk",
     "copy-icon": true,


### PR DESCRIPTION
The previously used runtime version (GNOME 44) has been EOL'd by the end of March 2024. Update to GNOME 46 to use a supported runtime.